### PR TITLE
Fixed secure boolean evaluation

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -186,7 +186,7 @@ ReverseProxy.prototype.setupHttpProxy = function (proxy, websocketsUpgrade, log,
         if (shouldRedirectToHttps(_this.certs, src, target, _this)) {
           redirectToHttps(req, res, target, opts.ssl, log);
         } else {
-          proxy.web(req, res, { target: target, secure: (proxy.options && proxy.options.secure) || true});
+          proxy.web(req, res, { target: target, secure: proxy.options && proxy.options.secure });
         }
       } else {
         respondNotFound(req, res);


### PR DESCRIPTION
The part in the brackets will always evaluate to false if secure is set to false.

Changing 
   `(proxy.options && proxy.options.secure) || true`
to 
   `proxy.options && proxy.options.secure`
fixes the issue

This fix should close #87